### PR TITLE
Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN chmod +x prepare_extra_vars.py
 VOLUME ./../app /app
 
 RUN pip install requests
+RUN apt install jq
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN chmod +x prepare_extra_vars.py
 VOLUME ./../app /app
 
 RUN pip install requests
-RUN apk install jq
+RUN apk add jq
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN chmod +x prepare_extra_vars.py
 # Répertoire contenant le source de l'application à déployer
 # Permet de récuperer le fichier templaté des extra_vars contenu dans src/main/resources
 VOLUME ./../app /app
+WORKDIR /app
 
 RUN pip install requests
-RUN apk add jq
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,6 @@ RUN chmod +x entrypoint.sh
 RUN chmod +x launch_job.py
 RUN chmod +x prepare_extra_vars.py
 
-# Répertoire contenant le source de l'application à déployer
-# Permet de récuperer le fichier templaté des extra_vars contenu dans src/main/resources
-VOLUME ./../app /app
-WORKDIR /app
-
 RUN pip install requests
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN chmod +x prepare_extra_vars.py
 VOLUME ./../app /app
 
 RUN pip install requests
-RUN apt install jq
+RUN apk install jq
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,14 +22,10 @@ Default filename is *tower_extra_vars_template.yml*, if you want to use another 
     steps:
       - name: Checkout my repo
         uses: actions/checkout@v2
-        with:
-          path: ./app
       - name: Invoke deploy action
-        env:
-          SECRETS_CONTEXT: ${{ tojson(secrets) }}
-        uses: ./tower-deploy-action
+        uses: opt-nc/tower-deploy-action@v1.1.0
         with:
-          vars: ${{ env.SECRETS_CONTEXT }}
+          vars: ${{ tojson(secrets) }}
           asset_url:  https://github.com/my_org/my_repo/releases/download/integration/my_app.jar
           tower_template_id : 45
           tower_url: ${{ secrets.TOWER_URL }}
@@ -47,15 +43,11 @@ Default filename is *tower_extra_vars_template.yml*, if you want to use another 
     steps:
       - name: Checkout my repo
         uses: actions/checkout@v2
-        with:
-          path: ./app
           ref: 1.0.0
       - name: Invoke deploy action
-        env:
-          SECRETS_CONTEXT: ${{ tojson(secrets) }}
-        uses: ./tower-deploy-action
+        uses: opt-nc/tower-deploy-action@v1.1.0
         with:
-          vars: ${{ env.SECRETS_CONTEXT }}
+          vars: ${{ tojson(secrets) }}
           asset_url:  https://github.com/my_org/my_repo/releases/download/1.0.0/my_app.jar
           tower_template_id : 46
           tower_url: ${{ secrets.TOWER_URL }}

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    EXTRA_VARS_TEMPLATE_FILENAME: ${{GITHUB_WORKSPACE}}${{ inputs.extravars_template_filename }}
+    EXTRA_VARS_TEMPLATE_FILENAME: ${{ env.GITHUB_WORKSPACE }}${{ inputs.extravars_template_filename }}
     ARTIFACT_URL: ${{ inputs.asset_url }}
     SECRETS_CONTEXT: ${{ inputs.vars }} 
     TOWER_TEMPLATE_ID: ${{ inputs.tower_template_id }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   extravars_template_filename:
     description: "Fichier yaml templaté contenant les extra_vars"
     required: true
-    default: 'tower_extra_vars_template.yml'
+    default: 'src/main/resources/tower_extra_vars_template.yml'
   vars:
     description: "Liste des variables (json) qui seront utilisées dans le template"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -36,13 +36,15 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{ inputs.extravars_template_filename }}
-    - ${{ inputs.vars }}
-    - ${{ inputs.asset_url }}
-    - ${{ inputs.tower_template_id }}
-    - ${{ inputs.tower_url }}
-    - ${{ inputs.tower_user }}
-    - ${{ inputs.tower_password }}
-    - ${{ inputs.tower_timeout }}
+  env:
+    EXTRA_VARS_TEMPLATE_FILENAME: ${{ inputs.extravars_template_filename }}
+    ARTIFACT_URL: ${{ inputs.asset_url }}
+    SECRETS_CONTEXT: ${{ inputs.vars }} 
+    TOWER_TEMPLATE_ID: ${{ inputs.tower_template_id }}
+    EXTRA_VARS_FILE: tmp_extra_vars.txt
+    TOWER_URL: ${{ inputs.tower_url }}
+    TOWER_USER: ${{ inputs.tower_user }}
+    TOWER_PASSWORD: ${{ inputs.tower_password }}
+    TOWER_TIMEOUT: ${{ inputs.tower_timeout }}
+
 

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    EXTRA_VARS_TEMPLATE_FILENAME: ${{ inputs.extravars_template_filename }}
+    EXTRA_VARS_TEMPLATE_FILENAME: ${{GITHUB_WORKSPACE}}${{ inputs.extravars_template_filename }}
     ARTIFACT_URL: ${{ inputs.asset_url }}
     SECRETS_CONTEXT: ${{ inputs.vars }} 
     TOWER_TEMPLATE_ID: ${{ inputs.tower_template_id }}
-    EXTRA_VARS_FILE: tmp_extra_vars.txt
+    EXTRA_VARS_FILE: ${{GITHUB_WORKSPACE}}/tmp_extra_vars.txt
     TOWER_URL: ${{ inputs.tower_url }}
     TOWER_USER: ${{ inputs.tower_user }}
     TOWER_PASSWORD: ${{ inputs.tower_password }}

--- a/action.yml
+++ b/action.yml
@@ -37,11 +37,11 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
-    EXTRA_VARS_TEMPLATE_FILENAME: ${{ env.GITHUB_WORKSPACE }}${{ inputs.extravars_template_filename }}
+    EXTRA_VARS_TEMPLATE_FILENAME: ${{ inputs.extravars_template_filename }}
     ARTIFACT_URL: ${{ inputs.asset_url }}
     SECRETS_CONTEXT: ${{ inputs.vars }} 
     TOWER_TEMPLATE_ID: ${{ inputs.tower_template_id }}
-    EXTRA_VARS_FILE: ${{GITHUB_WORKSPACE}}/tmp_extra_vars.txt
+    EXTRA_VARS_FILE: /tmp_extra_vars.txt
     TOWER_URL: ${{ inputs.tower_url }}
     TOWER_USER: ${{ inputs.tower_user }}
     TOWER_PASSWORD: ${{ inputs.tower_password }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,13 +11,16 @@
 
 export EXTRA_VARS_TEMPLATE_FILENAME="/github/workspace/app/src/main/resources/"$1
 export ARTIFACT_URL=$3
-export SECRETS_CONTEXT=$2
+export SECRETS_CONTEXT=$2 
 export TOWER_TEMPLATE_ID=$4
 export EXTRA_VARS_FILE="/github/workspace/tmp_extra_vars.txt"
 export TOWER_URL=$5
 export TOWER_USER=$6
 export TOWER_PASSWORD=$7
 export TOWER_TIMEOUT=$8
+
+# fix double quote secret value
+SECRETS_CONTEXT=$(echo $SECRETS_CONTEXT | sed -s 's,\\\\",\\\",g')
 
 /prepare_extra_vars.py
 /launch_job.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,16 +11,13 @@
 
 export EXTRA_VARS_TEMPLATE_FILENAME="/github/workspace/app/src/main/resources/"$1
 export ARTIFACT_URL=$3
-export SECRETS_CONTEXT=$2 
+export SECRETS_CONTEXT="$2" 
 export TOWER_TEMPLATE_ID=$4
 export EXTRA_VARS_FILE="/github/workspace/tmp_extra_vars.txt"
 export TOWER_URL=$5
 export TOWER_USER=$6
 export TOWER_PASSWORD=$7
 export TOWER_TIMEOUT=$8
-
-# fix double quote secret value
-SECRETS_CONTEXT=$(echo $SECRETS_CONTEXT | sed 's,\\\\",\\\",g')
 
 /prepare_extra_vars.py
 /launch_job.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,8 @@ export TOWER_USER=$6
 export TOWER_PASSWORD=$7
 export TOWER_TIMEOUT=$8
 
+echo "$2" | jq keys
+
 /prepare_extra_vars.py
 /launch_job.py
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,26 +1,4 @@
 #!/bin/sh -l
-
-# $1 extravars_template_filename
-# $2 vars
-# $3 asset_url
-# $4 tower_template_id
-# $5 tower_url
-# $6 tower_user
-# $7 tower_password
-# $8 tower_timeout
-
-export EXTRA_VARS_TEMPLATE_FILENAME=$1
-export ARTIFACT_URL=$3
-export SECRETS_CONTEXT="$2" 
-export TOWER_TEMPLATE_ID=$4
-export EXTRA_VARS_FILE="/github/workspace/tmp_extra_vars.txt"
-export TOWER_URL=$5
-export TOWER_USER=$6
-export TOWER_PASSWORD=$7
-export TOWER_TIMEOUT=$8
-
-echo "$2" | jq keys
-
 /prepare_extra_vars.py
 /launch_job.py
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@
 # $7 tower_password
 # $8 tower_timeout
 
-export EXTRA_VARS_TEMPLATE_FILENAME="/github/workspace/app/src/main/resources/"$1
+export EXTRA_VARS_TEMPLATE_FILENAME=$1
 export ARTIFACT_URL=$3
 export SECRETS_CONTEXT="$2" 
 export TOWER_TEMPLATE_ID=$4

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ export TOWER_PASSWORD=$7
 export TOWER_TIMEOUT=$8
 
 # fix double quote secret value
-SECRETS_CONTEXT=$(echo $SECRETS_CONTEXT | sed -s 's,\\\\",\\\",g')
+SECRETS_CONTEXT=$(echo $SECRETS_CONTEXT | sed 's,\\\\",\\\",g')
 
 /prepare_extra_vars.py
 /launch_job.py

--- a/prepare_extra_vars.py
+++ b/prepare_extra_vars.py
@@ -19,11 +19,16 @@ def prepare_secrets_list(vars_dict):
   
 # récupération des secrets Github dans l'environnement
 tmp_var_deploy = os.environ.get("SECRETS_CONTEXT")
+sys.stdout.write(tmp_var_deploy)
+
 tmp_var_deploy_dict = json.loads(tmp_var_deploy)
 sys.stdout.write(f"INFO: Environment variables processing...\n")
 
 # ajout des variables du job dans l'environnement
 tmp_var_deploy_dict["ARTIFACT_URL"] = os.environ.get("ARTIFACT_URL")
+
+# Tower workaround to force restart
+tmp_var_deploy_dict["GITHUB_RUN_ID"] = os.environ.get("GITHUB_RUN_ID")
 
 # récupération du nom du tempate extra_vars
 sys.stdout.write(f"INFO: YAML file template processing...\n")

--- a/prepare_extra_vars.py
+++ b/prepare_extra_vars.py
@@ -19,8 +19,6 @@ def prepare_secrets_list(vars_dict):
   
 # récupération des secrets Github dans l'environnement
 tmp_var_deploy = os.environ.get("SECRETS_CONTEXT")
-sys.stdout.write(tmp_var_deploy)
-
 tmp_var_deploy_dict = json.loads(tmp_var_deploy)
 sys.stdout.write(f"INFO: Environment variables processing...\n")
 

--- a/prepare_extra_vars.py
+++ b/prepare_extra_vars.py
@@ -46,7 +46,8 @@ sys.stdout.write(f"INFO: Generate EXTRA_VARS file...\n")
 output = replace_words(tempstr, final_var_deploy_dict)
 sys.stdout.write(f"{repr(output)}\n")
 
-writefile = open("tmp_extra_vars.txt", 'w+')
+extra_vars_file = os.environ.get("EXTRA_VARS_FILE")
+writefile = open(extra_vars_file, 'w+')
 writefile.write(output)
 writefile.close()
 


### PR DESCRIPTION
- specials caracters handling fix (like `"'` and those that are special for shell)
- `extravars_template_filename`  is now the entire file path so it could be placed anywhere (previously on `src/main/resources`)
- checkout on /app no more needed
- trick to get Tower restart app even when no conf changes : use special `$GITHUB_RUN_ID` var